### PR TITLE
Duplicate Asset Reference Data Object Fetching

### DIFF
--- a/src/Command/RemoveDuplicateAssetCommand.php
+++ b/src/Command/RemoveDuplicateAssetCommand.php
@@ -39,11 +39,14 @@ class RemoveDuplicateAssetCommand extends AbstractCommand
         //This message is temporary and is just here to demonstrate that the query is working
         $this->output->writeln("Found asset with {$result["total"]} duplicates ($dupString)");
 
-        $imageGalleryFields = $this->getImageGalleryFields();
+        $imageGalleryClasses = $this->getImageGalleryClasses();
 
-        foreach($imageGalleryFields as $field)
+        foreach($imageGalleryClasses as $galleryClass)
         {
-            $this->output->writeln("Image Gallery field: {$field["fieldName"]} in class: {$field["className"]}");
+            foreach($galleryClass["fields"] as $field)
+            {
+                $this->output->writeln("Found image gallery: $field in class: {$galleryClass["className"]}");
+            }
         }
 
         return 0;
@@ -89,7 +92,7 @@ class RemoveDuplicateAssetCommand extends AbstractCommand
             ->getSQL();
     }
 
-    private function getImageGalleryFields()
+    private function getImageGalleryClasses()
     {
         $classDefinitions = (new ClassDefinition\Listing())->load();
 
@@ -97,15 +100,22 @@ class RemoveDuplicateAssetCommand extends AbstractCommand
 
         foreach($classDefinitions as $def)
         {
+            $classGalleryFields = [];
+
             foreach($def->getFieldDefinitions() as $field)
             {
                 if($field->getFieldtype() === "imageGallery")
                 {
-                    $imageGalleryFields[] = [
-                        "className" => $def->getName(),
-                        "fieldName" => $field->getName()
-                    ];
+                    $classGalleryFields[] = $field->getName();
                 }
+            }
+
+            if(!empty($classGalleryFields))
+            {
+                $imageGalleryFields[] = [
+                    "className" => $def->getName(),
+                    "fields" => $classGalleryFields
+                ];
             }
         }
 


### PR DESCRIPTION
The command now finds all data object classes that contain image galleries and then searches for all data objects possessing image galleries that contain duplicate assets.

![image](https://github.com/TorqIT/duplicate-asset-cleanup-bundle/assets/68865874/884db430-e719-4f12-8092-58e74f518e08)
